### PR TITLE
Fix annotation equality

### DIFF
--- a/pybryt/annotations/annotation.py
+++ b/pybryt/annotations/annotation.py
@@ -142,7 +142,6 @@ class Annotation(ABC):
         """
         ... # pragma: no cover
 
-    @abstractmethod
     def __eq__(self, other: Any) -> bool:
         """
         Checks whether this annotation is equal to another object.
@@ -153,7 +152,10 @@ class Annotation(ABC):
         Returns:
             ``bool``: whether the objects are equal
         """
-        ... # pragma: no cover
+        return isinstance(other, type(self)) and  self.name == other.name and \
+            self.success_message == other.success_message and \
+            self.failure_message == other.failure_message and self.group == other.group and \
+            self.limit == other.limit
 
     def before(self, other_annotation: "Annotation", **kwargs) -> "BeforeAnnotation":
         """

--- a/pybryt/annotations/complexity/annotation.py
+++ b/pybryt/annotations/complexity/annotation.py
@@ -57,7 +57,7 @@ class ComplexityAnnotation(Annotation):
         Returns:
             ``bool``: whether the objects are equal
         """
-        return type(self) is type(other) and self.name == other.name and self.complexity is other.complexity
+        return super().__eq__(other) and self.complexity is other.complexity
 
 
 class TimeComplexity(ComplexityAnnotation):

--- a/pybryt/annotations/complexity/complexities.py
+++ b/pybryt/annotations/complexity/complexities.py
@@ -94,7 +94,7 @@ class constant(complexity):
 
 class logarithmic(complexity):
     """
-    Complexity class for logarithmic time: :math:`\\mathcal{O}(\log n)`
+    Complexity class for logarithmic time: :math:`\\mathcal{O}(\\log n)`
     """
 
     @staticmethod
@@ -114,7 +114,7 @@ class linear(complexity):
 
 class linearithmic(complexity):
     """
-    Complexity class for linearithmic time: :math:`\\mathcal{O}(n \log n)`
+    Complexity class for linearithmic time: :math:`\\mathcal{O}(n \\log n)`
     """
 
     @staticmethod

--- a/pybryt/annotations/relation.py
+++ b/pybryt/annotations/relation.py
@@ -58,7 +58,7 @@ class RelationalAnnotation(Annotation):
         Returns:
             ``bool``: whether the objects are equal
         """
-        return isinstance(other, type(self)) and self.children == other.children
+        return super().__eq__(other) and self.children == other.children
 
     @abstractmethod
     def check(self, observed_values: List[Tuple[Any, int]]) -> "AnnotationResult":

--- a/pybryt/annotations/value.py
+++ b/pybryt/annotations/value.py
@@ -137,7 +137,7 @@ class Value(Annotation):
         Returns:
             ``bool``: whether the objects are equal
         """
-        return isinstance(other, type(self)) and self.invariants == other.invariants and \
+        return super().__eq__(other) and self.invariants == other.invariants and \
             self.check_values_equal(self.initial_value, other.initial_value) and \
             self.atol == other.atol and self.rtol == other.rtol
 
@@ -337,7 +337,7 @@ class Attribute(Annotation):
         Returns:
             ``bool``: whether the objects are equal
         """
-        return isinstance(other, type(self)) and self.children == other.children
+        return super().__eq__(other) and self.children == other.children
 
     def to_dict(self) -> Dict[str, Any]:
         """


### PR DESCRIPTION
Changes how annotations are considered "equal" with `__eq__`.