### PR TITLE
Add caching for `pybryt.check`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,7 @@ dmypy.json
 /*.ipynb
 /*.pkl
 /notebooks
+.pybryt_cache
 
 # ignore docs build
 /docs/html

--- a/pybryt/student.py
+++ b/pybryt/student.py
@@ -303,7 +303,7 @@ class check:
             r.dump(res_path)
 
         ref_hash = hashlib.sha1("".join(r.name for r in res).encode()).hexdigest()
-        stu_path = f"student_impl_{ref_hash}.pkl"
+        stu_path = os.path.join(CACHE_DIR_NAME, f"student_impl_{ref_hash}.pkl")
         stu.dump(stu_path)
 
     def __enter__(self):

--- a/pybryt/student.py
+++ b/pybryt/student.py
@@ -142,6 +142,10 @@ class StudentImplementation(Serializable):
         Args:
             cache_dir (``str``, optional): the path to the cache directory
             combine (``bool``, optional): whether to combine the implementations
+
+        Returns:
+            ``StudentImplementation`` or ``list[StudentImplementation]``: the student implementations
+            loaded from the cache.
         """
         impls = []
         for impl_path in glob(os.path.join(cache_dir, _CACHE_STUDENT_IMPL_PREFIX.format("*"))):

--- a/tests/test_student.py
+++ b/tests/test_student.py
@@ -118,66 +118,71 @@ def test_check_cm(capsys):
     _, stu = generate_impl()
     mfp = stu.values
 
-    with mock.patch("pybryt.student.tracing_on") as mocked_tracing, mock.patch("pybryt.student.tracing_off"):
-        check_cm = check(ref)
-        with check_cm:
-            check_cm._observed = mfp
-
-    captured = capsys.readouterr()
-    expected = dedent("""\
-        REFERENCE: foo
-        SATISFIED: True
-        MESSAGES:
-          - SUCCESS: Sorted the sample correctly
-          - SUCCESS: Computed the size of the sample
-          - SUCCESS: computed the correct median
-    """)
-    assert captured.out == expected
-
-    with mock.patch("pybryt.student.tracing_on") as mocked_tracing, mock.patch("pybryt.student.tracing_off"):
-        ref_filename = pkg_resources.resource_filename(__name__, os.path.join("files", "expected_ref.pkl"))
-        check_cm = check(ref_filename)
-        with check_cm:
-            check_cm._observed = mfp
-
-        check_cm2 = check([ref_filename])
-        assert check_cm._ref == check_cm2._ref
-
-    captured = capsys.readouterr()
-    expected = dedent("""\
-        REFERENCE: foo
-        SATISFIED: True
-        MESSAGES:
-          - SUCCESS: Sorted the sample correctly
-          - SUCCESS: Computed the size of the sample
-          - SUCCESS: computed the correct median
-    """)
-    assert captured.out == expected
-
-    # check no action when tracing
-    global __PYBRYT_TRACING__
-    __PYBRYT_TRACING__ = True
-
-    try:
+    with mock.patch.object(check, "_cache_check") as mocked_cache:
         with mock.patch("pybryt.student.tracing_on") as mocked_tracing, mock.patch("pybryt.student.tracing_off"):
-            check_cm = check(ref)
+            check_cm = check(ref, cache=False)
             with check_cm:
-                pass
-            mocked_tracing.assert_not_called()
+                check_cm._observed = mfp
 
-    except:
-        __PYBRYT_TRACING__ = False
-        raise
+            mocked_cache.assert_not_called()
 
-    else:
-        __PYBRYT_TRACING__ = False
+        captured = capsys.readouterr()
+        expected = dedent("""\
+            REFERENCE: foo
+            SATISFIED: True
+            MESSAGES:
+              - SUCCESS: Sorted the sample correctly
+              - SUCCESS: Computed the size of the sample
+              - SUCCESS: computed the correct median
+        """)
+        assert captured.out == expected
 
-    # test errors
-    with pytest.raises(ValueError, match="Cannot check against an empty list of references"):
-        check([])
+        with mock.patch("pybryt.student.tracing_on") as mocked_tracing, mock.patch("pybryt.student.tracing_off"):
+            ref_filename = pkg_resources.resource_filename(__name__, os.path.join("files", "expected_ref.pkl"))
+            check_cm = check(ref_filename)
+            with check_cm:
+                check_cm._observed = mfp
 
-    with pytest.raises(TypeError, match="Invalid values in the reference list"):
-        check([ref, "path", 1])
+            mocked_cache.assert_called()
+
+            check_cm2 = check([ref_filename])
+            assert check_cm._ref == check_cm2._ref
+
+        captured = capsys.readouterr()
+        expected = dedent("""\
+            REFERENCE: foo
+            SATISFIED: True
+            MESSAGES:
+              - SUCCESS: Sorted the sample correctly
+              - SUCCESS: Computed the size of the sample
+              - SUCCESS: computed the correct median
+        """)
+        assert captured.out == expected
+
+        # check no action when tracing
+        global __PYBRYT_TRACING__
+        __PYBRYT_TRACING__ = True
+
+        try:
+            with mock.patch("pybryt.student.tracing_on") as mocked_tracing, mock.patch("pybryt.student.tracing_off"):
+                check_cm = check(ref)
+                with check_cm:
+                    pass
+                mocked_tracing.assert_not_called()
+
+        except:
+            __PYBRYT_TRACING__ = False
+            raise
+
+        else:
+            __PYBRYT_TRACING__ = False
+
+        # test errors
+        with pytest.raises(ValueError, match="Cannot check against an empty list of references"):
+            check([])
+
+        with pytest.raises(TypeError, match="Invalid values in the reference list"):
+            check([ref, "path", 1])
 
 
 def test_generate_student_impls():


### PR DESCRIPTION
This PR adds caching of student implementations and results generated by the `pybryt.check` context manager. It also includes support for combining these cached student implementations into a single object for later grading.

Closes #53