### PR TITLE
Fixing #64

### DIFF
--- a/pybryt/annotations/value.py
+++ b/pybryt/annotations/value.py
@@ -169,6 +169,9 @@ class Value(Annotation):
     def check_values_equal(value, other_value, atol = None, rtol = None):
         """
         """
+        if isinstance(value, Iterable) ^ isinstance(other_value, Iterable):
+            return False
+
         if atol is None:
             atol = 0
         if rtol is None:


### PR DESCRIPTION
Asserts that a value cannot be satisfied if the value xor the observed value is an iterable. This fixes an issue introduced by using numpy to perform tolerance comparisons when comparing a single number with an empty iterable.

Closes #64