### PR TITLE
Fix tracing at top level

### DIFF
--- a/pybryt/execution/tracing.py
+++ b/pybryt/execution/tracing.py
@@ -216,6 +216,7 @@ def tracing_on(frame=None, tracing_func=None):
     vn2 = f"sys_{make_secret()}"
     frame.f_globals[vn] = tracing_func
     exec(f"import sys as {vn2}\n{vn2}.settrace({vn})", frame.f_globals, frame.f_locals)
+    frame.f_trace = tracing_func
 
 
 class no_tracing:


### PR DESCRIPTION
Fixes tracing so that code in the frame from which tracing is initialized is also traced. This fixes the issue in #61.

Closes #61