### PR TITLE
Invalid usage of NoReturn

### DIFF
--- a/pybryt/annotations/annotation.py
+++ b/pybryt/annotations/annotation.py
@@ -4,7 +4,7 @@ __all__ = ["Annotation", "AnnotationResult"]
 
 from abc import ABC, abstractmethod
 from collections import OrderedDict
-from typing import Any, Dict, List, NoReturn, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 
 _TRACKED_ANNOTATIONS = []
@@ -67,7 +67,7 @@ class Annotation(ABC):
         ret = f"pybryt.{self.__class__.__name__}"
         return ret
     
-    def _track(self) -> NoReturn:
+    def _track(self) -> None:
         """
         Tracks this annotation in ``_TRACKED_ANNOTATIONS`` and updates ``_GROUP_INDICES`` with the
         index of the annotation if ``self.group`` is present. If the annotation has children
@@ -106,7 +106,7 @@ class Annotation(ABC):
         return _TRACKED_ANNOTATIONS
 
     @staticmethod
-    def reset_tracked_annotations() -> NoReturn:
+    def reset_tracked_annotations() -> None:
         """
         Resets the list of tracked annotations and the mapping of group names to indices in that
         list.

--- a/pybryt/annotations/collection.py
+++ b/pybryt/annotations/collection.py
@@ -2,7 +2,7 @@
 
 __all__ = ["Collection"]
 
-from typing import Any, Dict, List, NoReturn, Tuple
+from typing import Any, Dict, List, Tuple
 
 from .annotation import Annotation, AnnotationResult
 
@@ -104,7 +104,7 @@ class Collection(Annotation):
         })
         return d
 
-    def add(self, annotation: Annotation) -> NoReturn:
+    def add(self, annotation: Annotation) -> None:
         """
         Adds an annotation to this collection.
 
@@ -121,7 +121,7 @@ class Collection(Annotation):
         except ValueError:  # pragma: no cover
             pass
 
-    def remove(self, annotation: Annotation) -> NoReturn:
+    def remove(self, annotation: Annotation) -> None:
         """
         Removes an annotation from this collection.
 

--- a/pybryt/integrations/otter.py
+++ b/pybryt/integrations/otter.py
@@ -13,7 +13,7 @@ from otter.assign.assignment import Assignment
 from otter.plugins import AbstractOtterPlugin
 from otter.test_files import GradingResults
 from otter.utils import get_source
-from typing import Any, Dict, List, NoReturn, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from .. import ReferenceImplementation, StudentImplementation
 from ..execution import NBFORMAT_VERSION
@@ -30,7 +30,7 @@ class OtterPlugin(AbstractOtterPlugin):
     _generate_report = None
     _student_impl = None
 
-    def during_assign(self, assignment: Assignment) -> NoReturn:
+    def during_assign(self, assignment: Assignment) -> None:
         """
         This event runs during ``otter assign`` and compiles the list of references indicated in the
         plugin config, placing the pickled reference implementations in the otuput directories. The
@@ -55,7 +55,7 @@ class OtterPlugin(AbstractOtterPlugin):
             stp = assignment.result / 'student' / ref_fn
             shutil.copy(str(agp), str(stp))
 
-    def during_generate(self, otter_config: Dict[str, Any], assignment: Assignment) -> NoReturn:
+    def during_generate(self, otter_config: Dict[str, Any], assignment: Assignment) -> None:
         """
         This event runs during ``otter generate`` and, if ``otter assign`` was run, adds the cached
         reference implementations from that run or compiles the indicated references if it was not
@@ -88,7 +88,7 @@ class OtterPlugin(AbstractOtterPlugin):
         if assignment is not None:
             os.chdir(cwd)
 
-    def _generate_impl_report(self, refs: List[ReferenceImplementation], group: Optional[str] = None) -> NoReturn:
+    def _generate_impl_report(self, refs: List[ReferenceImplementation], group: Optional[str] = None) -> None:
         """
         Generates and caches a student implementation from the submission path being graded as well
         as a report of what reference(s) were satisfied, if any, and the messages received from 
@@ -124,7 +124,7 @@ class OtterPlugin(AbstractOtterPlugin):
         self._generated_report = report
         self._student_impl = stu
     
-    def _cache_student_impl(self, results: GradingResults, stu: StudentImplementation) -> NoReturn:
+    def _cache_student_impl(self, results: GradingResults, stu: StudentImplementation) -> None:
         """
         Caches the student implementation object as a base-64-encoded string in the grading results
         to be retrieved outside of the grading process.
@@ -139,7 +139,7 @@ class OtterPlugin(AbstractOtterPlugin):
         results.set_plugin_data(self.IMPORTABLE_NAME, data)
 
     @classmethod
-    def _remove_plugin_calls(cls, nb: Dict[str, Any]) -> NoReturn:
+    def _remove_plugin_calls(cls, nb: Dict[str, Any]) -> None:
         """
         Removes calls to this Otter plugin from a notebook to ensure that a loop isn't created.
         Modifies the notebook in-place.
@@ -155,7 +155,7 @@ class OtterPlugin(AbstractOtterPlugin):
                     source[i] = "# " + source[i]
             cell["source"] = "\n".join(source)
 
-    def from_notebook(self, *ref_paths: str, group: Optional[str] = None) -> NoReturn:
+    def from_notebook(self, *ref_paths: str, group: Optional[str] = None) -> None:
         """
         This event runs when ``otter.Notebook.run_plugin`` is called to execute this plugin. It
         attempts to force-save the notebook and then loads the references indicated and generates
@@ -213,7 +213,7 @@ class OtterPlugin(AbstractOtterPlugin):
         self._remove_plugin_calls(submission)
         return submission
 
-    def after_grading(self, results: GradingResults) -> NoReturn:
+    def after_grading(self, results: GradingResults) -> None:
         """
         Generates an implementation report and caches the student implementation in the grading 
         results.

--- a/pybryt/reference.py
+++ b/pybryt/reference.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from copy import deepcopy
 from textwrap import indent
-from typing import Any, Dict, List, NoReturn, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from .annotations import Annotation, AnnotationResult
 from .utils import get_stem, notebook_to_string, Serializable

--- a/pybryt/student.py
+++ b/pybryt/student.py
@@ -14,7 +14,7 @@ from contextlib import contextmanager
 from glob import glob
 from multiprocessing import Process, Queue
 from types import FrameType
-from typing import Any, Dict, List, NoReturn, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from .execution import (
     create_collector, execute_notebook, _get_tracing_frame, NBFORMAT_VERSION, tracing_off, 
@@ -80,7 +80,7 @@ class StudentImplementation(Serializable):
 
         self._execute(timeout, addl_filenames=addl_filenames, output=output)
 
-    def _execute(self, timeout: Optional[int], addl_filenames: List[str] = [], output: Optional[str] = None) -> NoReturn:
+    def _execute(self, timeout: Optional[int], addl_filenames: List[str] = [], output: Optional[str] = None) -> None:
         """
         Executes the notebook ``self.nb``.
 

--- a/pybryt/utils.py
+++ b/pybryt/utils.py
@@ -11,7 +11,7 @@ import time
 import nbformat
 
 from abc import ABC, abstractmethod
-from typing import Any, List, NoReturn, Optional, Union
+from typing import Any, List, Optional, Union
 from IPython import get_ipython
 from IPython.display import publish_display_data
 
@@ -30,7 +30,7 @@ def pickle_and_hash(obj: Any) -> str:
     return hashlib.sha512(s).hexdigest()
 
 
-def filter_picklable_list(lst: List[Any]) -> NoReturn:
+def filter_picklable_list(lst: List[Any]) -> None:
     """
     Removes all elements from a list that cannot be pickled with ``dill``.
 
@@ -127,7 +127,7 @@ def save_notebook(filename, timeout=10):
         return curr != md5
 
 
-def get_stem(fp):
+def get_stem(fp) -> str:
     """
     Returns the stem of a filepath.
 
@@ -153,7 +153,7 @@ class Serializable(ABC):
         """
         ... # pragma: no cover
 
-    def dump(self, dest: Optional[str] = None) -> NoReturn:
+    def dump(self, dest: Optional[str] = None) -> None:
         """
         Pickles this object to a file.
 


### PR DESCRIPTION
The `NoReturn` annotation means that the program will exit, but its being used in place of `None`, which is what you should use if the function doesn't return a value.

