### PR TITLE
Use the `FrameTracer` class in the executed notebook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file, and this pr
 
 * Added complexity unions for combining complexity classes per [#155](https://github.com/microsoft/pybryt/issues/155)
 * Added a return value annotation per [#144](https://github.com/microsoft/pybryt/issues/144)
+* Updated the notebook execution template to use `FrameTracer`
 
 ## 0.4.0 - 2022-01-12
 


### PR DESCRIPTION
Updates the notebook cell templates for activating tracing to use `FrameTracer` instead of calling `create_collector` and `tracing_on`/`tracing_off` directly.