### PR TITLE
Update GitHub Action docs with checkout step

### DIFF
--- a/docs/github_action.rst
+++ b/docs/github_action.rst
@@ -50,6 +50,9 @@ Inside this file, define the following action configuration:
       build:
         runs-on: ubuntu-latest
         steps:
+          - name: Checkout
+            uses: actions/checkout@v3
+            
           - name: Run PyBryt
             uses: microsoft/pybryt-action@v0.1.1
             with:
@@ -88,6 +91,9 @@ configuration like this:
       build:
         runs-on: ubuntu-latest
         steps:
+          - name: Checkout
+            uses: actions/checkout@v3
+          
           - name: Run PyBryt
             id: pybryt
             uses: microsoft/pybryt-action@v0.1.1


### PR DESCRIPTION
To access repo files, the repo will need to be checked-out on to the runner. Otherwise the given example workflows won't work (file not found error).